### PR TITLE
fix. folder item unselect

### DIFF
--- a/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderActivity.kt
+++ b/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderActivity.kt
@@ -73,10 +73,6 @@ class FolderActivity : BaseActivity<ActivityFolderBinding>(R.layout.activity_fol
 
         })
 
-        folderViewModel.test.observe(this, Observer {
-            listAdapter.selectClearItems()
-        })
-
         folderViewModel.selectImageButton.observe(this, Observer {
             binding.ibSelectImage.text = it
             when(it) {
@@ -89,6 +85,10 @@ class FolderActivity : BaseActivity<ActivityFolderBinding>(R.layout.activity_fol
                     binding.folderRectangleButton.animate().translationY(0f)
                 }
             }
+        })
+
+        folderViewModel.clearSelected.observe(this, Observer {
+            listAdapter.notifyClearSelect()
         })
     }
 

--- a/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderAdapter.kt
+++ b/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderAdapter.kt
@@ -34,9 +34,6 @@ class FolderAdapter(
         holder.bind(item, position)
     }
 
-    fun selectClearItems(){
-    }
-
     inner class FolderViewHolder constructor(val binding: RowDetailFolderBinding) :
         RecyclerView.ViewHolder(binding.root) {
 
@@ -63,6 +60,10 @@ class FolderAdapter(
                 }
             }
         }
+    }
+
+    fun notifyClearSelect() {
+        notifyDataSetChanged()
     }
 }
 

--- a/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderViewModel.kt
+++ b/presentation/src/main/java/com/ddd4/dropit/presentation/ui/folder/FolderViewModel.kt
@@ -54,7 +54,7 @@ class FolderViewModel @ViewModelInject constructor(
     private val _item = SingleLiveEvent<Long>()
     val item: SingleLiveEvent<Long> = _item
 
-    val test = SingleLiveEvent<Unit>()
+    val clearSelected = SingleLiveEvent<Void>()
 
     init {
         initView()
@@ -104,6 +104,7 @@ class FolderViewModel @ViewModelInject constructor(
     fun selectImageButtonClick() {
         if (_selectedImageState.value!!) {
             _selectImageButton.value = "선택"
+            clearSelected.call()
         } else {
             _selectImageButton.value = "취소"
         }


### PR DESCRIPTION
# HOTFIX PR
- 폴더 아이템 다중선택 해제

## 설명
- 폴더 아이템 다중선택 해제

## 작업사항
- [x] 폴더 내 아이템 다중 선택 후 "취소" 버튼 클릭 시 해제하도록 수정

## PR Type
- [x] 버그 픽스
- [ ] 문서내용 변경  (README, Docstring, API문서, 주석 등)
- [ ] 그외 기타
