### PR TITLE
fix. 카테고리 아이템 목록 겹침 현상 수정, 코드 수정

### DIFF
--- a/presentation/src/main/java/com/ddd4/dropit/presentation/ui/add/adapter/AddCategoryAdapter.kt
+++ b/presentation/src/main/java/com/ddd4/dropit/presentation/ui/add/adapter/AddCategoryAdapter.kt
@@ -1,11 +1,9 @@
 package com.ddd4.dropit.presentation.ui.add.adapter
 
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
-import androidx.databinding.DataBindingUtil
 import androidx.recyclerview.widget.RecyclerView
-import com.ddd4.dropit.presentation.R
+import com.ddd4.dropit.presentation.BR
 import com.ddd4.dropit.presentation.databinding.RowAddCategoryBinding
 import com.ddd4.dropit.presentation.entity.PresentationEntity
 import com.ddd4.dropit.presentation.util.ItemClickListener
@@ -18,28 +16,31 @@ class AddCategoryAdapter(
     private var selectedPosition: Int = -1
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CategoryViewHolder {
-        return CategoryViewHolder(
-            LayoutInflater.from(parent.context).inflate(R.layout.row_add_category, parent, false))
+        val binding = RowAddCategoryBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return CategoryViewHolder(binding)
     }
 
     override fun getItemCount(): Int = if (items != null) items!!.size else 0
 
     override fun onBindViewHolder(holder: CategoryViewHolder, position: Int) {
-        holder.setIsRecyclable(false)
-        holder.binding.item = items!![position]
-        holder.binding.isSelected = false
-
-        holder.itemView.setOnClickListener {
-            if (selectedPosition != position) {
-                notifyItemChanged(selectedPosition)
-                holder.binding.isSelected = true
-                selectedPosition = position
-                clickListener.onItemClicked(items!![position])
-            }
-        }
+        holder.bind(items!![position])
     }
 
-    class CategoryViewHolder(view: View): RecyclerView.ViewHolder(view) {
-        val binding: RowAddCategoryBinding = DataBindingUtil.bind(view)!!
+    inner class CategoryViewHolder constructor(
+        val binding: RowAddCategoryBinding
+    ) : RecyclerView.ViewHolder(binding.root){
+
+        fun bind(item: PresentationEntity.Category) {
+            binding.setVariable(BR.item, item)
+            binding.isSelected = false
+            itemView.setOnClickListener {
+                if (selectedPosition != adapterPosition) {
+                    binding.isSelected = true
+                    notifyItemChanged(selectedPosition)
+                    selectedPosition = adapterPosition
+                    clickListener.onItemClicked(item)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
# PATCH PR

## 설명
아이템 추가 시 카테고리 리스트에서 뷰가 겹치는 현상을 수정함.

## 작업사항
- [x] onBindViewHolder 내용을 ViewHolder로 이동.
- [x] setIsRecyclable 제거.

## PR 타입
- [ ] 새 기능
- [ ] 큰 변경사항
- [ ] 코드스타일 수정
- [x] 리펙터링
- [ ] 문서내용 변경
- [ ] 그외 기타

